### PR TITLE
add GA4

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -107,6 +107,12 @@ module.exports = {
     [
       '@docusaurus/preset-classic',
       {
+        gtag: {
+          trackingID: 'G-H36K1GKY2H',
+          anonymizeIP: true,
+        },
+      },
+      {
         docs: {
           path: '../docs',
           editUrl:

--- a/website/package.json
+++ b/website/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "^2.4.0",
+    "@docusaurus/plugin-google-gtag": "^2.4.1",
     "@docusaurus/preset-classic": "^2.4.0",
     "classnames": "^2.2.6",
     "clsx": "^1.1.1",


### PR DESCRIPTION
This PR utilizes the [Docusurus gtag plugin](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-google-gtag) to connect with Google Analytics (GA4).