### PR TITLE
Enable deep linking for video search and tags

### DIFF
--- a/website/src/components/VideoPlayer/FilterBar.jsx
+++ b/website/src/components/VideoPlayer/FilterBar.jsx
@@ -5,6 +5,7 @@ export default function FilterBar({
   categories,
   selectedCategories,
   onCategoryToggle,
+  onClearFilters,
   searchQuery,
   onSearch,
   totalVideos,
@@ -39,9 +40,7 @@ export default function FilterBar({
           {selectedCategories.length > 0 && (
             <button
               className={styles.clearButton}
-              onClick={() =>
-                selectedCategories.forEach(cat => onCategoryToggle(cat))
-              }
+              onClick={onClearFilters}
             >
               Clear Filters
             </button>

--- a/website/src/components/VideoPlayer/VideoPlayer.jsx
+++ b/website/src/components/VideoPlayer/VideoPlayer.jsx
@@ -5,15 +5,33 @@ import FilterBar from './FilterBar.jsx';
 import VideoModal from './VideoModal.jsx';
 
 export default function VideoPlayer() {
+  const CATEGORIES = ['quantum', 'XR', 'AI', 'space'];
+  const SEARCH_PARAM = 'search';
+  const TAGS_PARAM = 'tags';
+
+  const getInitialFilters = () => {
+    if (typeof window === 'undefined') {
+      return { initialCategories: [], initialSearch: '' };
+    }
+
+    const params = new URLSearchParams(window.location.search);
+    const initialSearch = params.get(SEARCH_PARAM) || '';
+    const initialCategories = (params.get(TAGS_PARAM) || '')
+      .split(',')
+      .map(tag => tag.trim())
+      .filter(tag => CATEGORIES.includes(tag));
+
+    return { initialCategories, initialSearch };
+  };
+
+  const { initialCategories, initialSearch } = getInitialFilters();
   const [videos, setVideos] = useState([]);
   const [filteredVideos, setFilteredVideos] = useState([]);
-  const [selectedCategories, setSelectedCategories] = useState([]);
-  const [searchQuery, setSearchQuery] = useState('');
+  const [selectedCategories, setSelectedCategories] = useState(initialCategories);
+  const [searchQuery, setSearchQuery] = useState(initialSearch);
   const [selectedVideo, setSelectedVideo] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-
-  const CATEGORIES = ['quantum', 'XR', 'AI', 'space'];
 
   // Load videos from JSON
   useEffect(() => {
@@ -74,6 +92,57 @@ export default function VideoPlayer() {
     setSearchQuery(query);
   };
 
+  const handleClearFilters = () => {
+    setSelectedCategories([]);
+  };
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const handlePopState = () => {
+      const params = new URLSearchParams(window.location.search);
+      const urlSearch = params.get(SEARCH_PARAM) || '';
+      const urlCategories = (params.get(TAGS_PARAM) || '')
+        .split(',')
+        .map(tag => tag.trim())
+        .filter(tag => CATEGORIES.includes(tag));
+
+      setSearchQuery(urlSearch);
+      setSelectedCategories(urlCategories);
+    };
+
+    window.addEventListener('popstate', handlePopState);
+    return () => window.removeEventListener('popstate', handlePopState);
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const params = new URLSearchParams(window.location.search);
+    const nextSearch = searchQuery.trim();
+    const nextTags = [...selectedCategories].sort();
+
+    if (nextSearch) {
+      params.set(SEARCH_PARAM, nextSearch);
+    } else {
+      params.delete(SEARCH_PARAM);
+    }
+
+    if (nextTags.length > 0) {
+      params.set(TAGS_PARAM, nextTags.join(','));
+    } else {
+      params.delete(TAGS_PARAM);
+    }
+
+    const nextQuery = params.toString();
+    const nextUrl = `${window.location.pathname}${nextQuery ? `?${nextQuery}` : ''}${window.location.hash}`;
+    const currentUrl = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+
+    if (nextUrl !== currentUrl) {
+      window.history.pushState({}, '', nextUrl);
+    }
+  }, [selectedCategories, searchQuery]);
+
   if (loading) {
     return (
       <div className={styles.container}>
@@ -101,6 +170,7 @@ export default function VideoPlayer() {
         categories={CATEGORIES}
         selectedCategories={selectedCategories}
         onCategoryToggle={handleCategoryToggle}
+        onClearFilters={handleClearFilters}
         searchQuery={searchQuery}
         onSearch={handleSearch}
         totalVideos={videos.length}


### PR DESCRIPTION
## Why
Video library filters were local-only, so selected tags and search text could not be shared via URL, and browser back/forward did not restore filter state.

## What changed
- Initialize video filter state from URL query params on page load.
- Persist filter changes to the URL using `search` (text query) and `tags` (comma-separated categories).
- Listen to browser `popstate` so back/forward navigation restores search and tag selections.
- Update clear-filter behavior to clear all selected tags in one state update and one history entry.

## Notes for reviewers
- Tag values are validated against supported categories before applying from URL.
- Tags are sorted before writing to the URL to keep deep links stable.